### PR TITLE
fix: allow partial user profile updates with optional fields

### DIFF
--- a/backend/services/auth/src/routes/auth.routes.ts
+++ b/backend/services/auth/src/routes/auth.routes.ts
@@ -92,13 +92,12 @@ export default async function authRoutes(fastify: FastifyInstance) {
 
     // Call User service to set online status
     try {
-      await axios.patch(`http://user-service:5000/internal/users/${user.id}/online`, {
+      await axios.patch(`http://user-service:5000/internal/${user.id}/online`, {
         online: true
       });
     } catch (err) {
       fastify.log.warn({ userId: user.id }, 'Failed to update online status');
     }
-
     return reply.send({
       token,
       user: {

--- a/backend/services/user/src/routes/internal.routes.ts
+++ b/backend/services/user/src/routes/internal.routes.ts
@@ -13,13 +13,13 @@ export default async function internalRoutes(fastify: FastifyInstance) {
       return reply.code(403).send({ error: 'Forbidden: Only auth service can create profiles' });
     }
 
-    const { id, email, display_name } = request.body;
+    const { id, email, display_name} = request.body;
 
     try {
       fastify.db.prepare(`
-        INSERT INTO users (id, email, display_name, avatar_url)
-        VALUES (?, ?, ?, ?)
-      `).run(id, email, display_name, 'default.png');
+        INSERT INTO users (id, email, display_name, bio, avatar_url)
+        VALUES (?, ?, ?, ?, ?)
+      `).run(id, email, display_name, "Hi!", 'default.png');
 
       fastify.log.info({ userId: id, email }, 'User profile created');
       return reply.code(201).send({ message: 'Profile created' });
@@ -63,11 +63,11 @@ export default async function internalRoutes(fastify: FastifyInstance) {
     }
   });
 
-  // PATCH /internal/users/:userId/online - Update online status (internal only)
+  // PATCH /internal/:userId/online - Update online status (internal only)
   fastify.patch<{ 
       Params: { userId: string },
       Body: { online: boolean }
-  }>('/users/:userId/online', async (request, reply) => {
+  }>('/:userId/online', async (request, reply) => {
       const userId = parseInt(request.params.userId, 10);
       const { online } = request.body;
 

--- a/backend/services/user/src/routes/user.routes.ts
+++ b/backend/services/user/src/routes/user.routes.ts
@@ -41,8 +41,9 @@ export default async function userRoutes(fastify: FastifyInstance) {
     const { userId } = request.user!;
     const { display_name, bio, avatar_url } = request.body;
 
+    //CHECK LATER W FRONTEND
     //prevent setting avatar to null/empty, undefined will keep it same
-    const avatarUrl = avatar_url || undefined;
+    // const avatarUrl = avatar_url || undefined;
 
     fastify.db.prepare(`
       UPDATE users

--- a/backend/shared/schemas/user.schema.ts
+++ b/backend/shared/schemas/user.schema.ts
@@ -8,11 +8,14 @@ export const CreateProfileSchema = Type.Object({
 });
 
 // Schema for updating user profile
-export const UpdateProfileSchema = Type.Object({
-  display_name: Type.Optional(Type.String({ minLength: 1, maxLength: 50 })),
-  bio: Type.Optional(Type.String({ maxLength: 500 })),
-  avatar_url: Type.Optional(Type.String())
-});
+export const UpdateProfileSchema = Type.Partial(
+  Type.Object({
+  display_name: Type.String({ minLength: 1, maxLength: 50 }),
+  bio: Type.String({ minLength: 1, maxLength: 500 }),
+  avatar_url: Type.String()
+}),
+ { minProperties: 1 }
+);
 
 // Schema for recording match results
 export const MatchResultSchema = Type.Object({

--- a/frontend/src/user.ts
+++ b/frontend/src/user.ts
@@ -4,10 +4,31 @@ export async function getUser(id: number|string, gateway = window.location.origi
 }
 
 export async function updateMe(token: string, data: { display_name?: string, bio?: string }, gateway = window.location.origin) {
+  // Filter out empty/undefined values to only send fields that should be updated
+  const updates: { display_name?: string, bio?: string } = {};
+  
+  if (data.display_name && data.display_name.trim()) {
+    updates.display_name = data.display_name.trim();
+  }
+  if (data.bio && data.bio.trim()) {
+    updates.bio = data.bio.trim();
+  }
+
+  // Ensure at least one field is being updated
+  if (Object.keys(updates).length === 0) {
+    throw new Error("At least one field (display_name or bio) must be provided");
+  }
+
   const r = await fetch(`${gateway}/api/user/me`, {
     method: "PUT",
     headers: { "Content-Type":"application/json", Authorization: "Bearer " + token },
-    body: JSON.stringify(data)
+    body: JSON.stringify(updates)
   });
+  
+  if (!r.ok) {
+    const error = await r.json();
+    throw new Error(error.message || 'Update failed');
+  }
+  
   return r.json();
 }


### PR DESCRIPTION
- Update UpdateProfileSchema to use Type.Partial
- Frontend now only sends non-empty fields in update requests
- Add validation to require at least one field when updating
- Fix internal online status route path (/internal/:userId/online)
- Add default bio